### PR TITLE
ENH: add singularity, some common cmdline tools, and datalad-container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,14 +44,20 @@ RUN { \
 	echo '#deb-src http://neuro.debian.net/debian-devel trusty main'; \
 } > /etc/apt/sources.list.d/neurodebian.sources.list
 
+# From APT repositories install git-annex required by datalad,
+# singularity-container - so users could go all the way YODA within
+# this Docker, and a number of useful utilities which users could use
+# in their Terminal
 RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \
            git-annex-standalone \
+		   singularity-container \
+		   vim wget time ncdu curl procps pigz less tree \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER
-RUN pip install --no-cache-dir datalad[full] pydra
+RUN pip install --no-cache-dir datalad[full] datalad-container pydra
 RUN pip install --no-cache-dir https://github.com/dandi/dandi-cli/archive/master.zip
 RUN cd /data && datalad install -r ///labs/svoboda ///labs/buzsaki \
     ///labs/churchland ///allen-brain-observatory/


### PR DESCRIPTION
Well, for singularity to work, docker container must be ran in `--privileged` mode.  Is that an unlikely case for the hub? ;) If not -- it would fail with something like

```shell
jovyan@bd27290e917a:/tmp/containers$ singularity run images/bids/bids-validator--1.3.12.sing --help
Singularity: action-suid (U=0,P=896)> Could not virtualize file system namespace: Operation not permitted

ERROR  : Could not virtualize file system namespace: Operation not permitted
Singularity: action-suid (U=0,P=896)> Retval = 255

ABORT  : Retval = 255
``` 