### PR TITLE
Enh Update to Jupyterhub 0.9.1

### DIFF
--- a/dandi-info/cluster-autoscaler-multi-asg.yaml.j2
+++ b/dandi-info/cluster-autoscaler-multi-asg.yaml.j2
@@ -138,7 +138,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.15.5
+        - image: k8s.gcr.io/cluster-autoscaler:v1.18.2
           name: cluster-autoscaler
           resources:
             limits:
@@ -154,8 +154,8 @@ spec:
             - --cloud-provider=aws
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
-            - --nodes=1:5:nodes.dandihub.k8s.local
-            - --nodes=1:10:spot-ig.dandihub.k8s.local
+            - --nodes=1:5:nodes.{{ namespace }}.k8s.local
+            - --nodes=1:10:spot-ig.{{ namespace }}.k8s.local
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/dandi-info/group_vars/all
+++ b/dandi-info/group_vars/all
@@ -1,13 +1,13 @@
 ---
-namespace: dandihub
+namespace: dandihub2
 aws_region: us-east-2
 ansible_ssh_private_key_file: ~/.ssh/dandi-satra.pem
 node_size: t3a.medium
 node_volume_size: 50
 node_count: 1
-jupyterhub_chart_version: 0.8.2
+jupyterhub_chart_version: 0.9.0
 singleuser_image_repo: satra/dandihub
-singleuser_image_tag: fe5a02ae
+singleuser_image_tag: d1f8d7f5
 helm_chart_repo_name: jupyterhub
 helm_chart_repo_url: https://jupyterhub.github.io/helm-chart/
 github_client_id: !vault |

--- a/dandi-info/group_vars/all
+++ b/dandi-info/group_vars/all
@@ -5,7 +5,7 @@ ansible_ssh_private_key_file: ~/.ssh/dandi-satra.pem
 node_size: t3a.medium
 node_volume_size: 50
 node_count: 1
-jupyterhub_chart_version: 0.9.0
+jupyterhub_chart_version: 0.9.1
 singleuser_image_repo: satra/dandihub
 singleuser_image_tag: d1f8d7f5
 helm_chart_repo_name: jupyterhub

--- a/dandi-info/teardown.yml
+++ b/dandi-info/teardown.yml
@@ -52,6 +52,7 @@
         stat:
           path: /home/ec2-user/cluster-autoscaler-multi-asg.yaml
         register: autoscaler_yaml
+        tags: always
 
       - block:
         # Need to remove the spot group and autoscaler as well

--- a/dandi-info/z2jh.yml
+++ b/dandi-info/z2jh.yml
@@ -114,7 +114,7 @@
         changed_when: False
         register: kci_log
 
-      - aws_az_facts:
+      - aws_az_info:
         register: az_facts
 
       - name: Create Kubernetes cluster
@@ -141,17 +141,6 @@
         retries: 20
         delay: 30
         changed_when: False
-
-
-
-      # Enable dynamic storage on your Kubernetes cluster
-      - name: Create storageclass.yaml config file
-        template:
-          src: storageclass.yaml.j2
-          dest: /home/ec2-user/storageclass.yaml
-
-      - name: Apply storageclass config file
-        command: kubectl apply -f /home/ec2-user/storageclass.yaml
 
       # Create filesystem for k8s
       - ec2_group_info:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,14 @@
-FROM jupyter/datascience-notebook:dc9744740e12
+FROM jupyter/datascience-notebook:612aa5710bf9
 
-RUN pip install --no-cache-dir nwbwidgets==0.2.0
-RUN pip install --no-cache-dir itkwidgets==0.25.3
-RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets@0.25.3
+RUN pip install --no-cache-dir itkwidgets==0.32.0
+RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-matplotlib jupyterlab-datawidgets itkwidgets@0.32.0
 
-# Install allendsk but upgrade pynwb
-RUN pip install --no-cache-dir allensdk
-RUN pip install --no-cache-dir --upgrade pynwb
+RUN pip install --no-cache-dir nwbwidgets zarr pydra dandi spikeinterface
 
-RUN pip install --no-cache-dir zarr pydra dandi
+RUN conda create -n allen python=3.8 pip numpy cython numexpr
+RUN HDF5_DIR=/opt/conda BLOSC_DIR=/opt/conda LZO_DIR=/opt/conda BZIP2_DIR=/opt/conda /opt/conda/envs/allen/bin/pip install tables==3.5.1
+RUN /opt/conda/envs/allen/bin/pip install --no-cache-dir ipfx
+RUN conda clean -tipsy
 
 RUN pip install --no-cache-dir nbgitpuller
 RUN gitpuller https://github.com/dandi/example-notebooks master dandi-notebooks


### PR DESCRIPTION
the current hub also uses:
- kubernetes 1.18
- kops 1.18
- autoscaler 1.18

closes https://github.com/dandi/example-notebooks/pull/2