### PR TITLE
Add libnss-wrapper to docker images for Nebari deployments

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -32,6 +32,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
         brave-browser \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
+        libnss-wrapper \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
    && chown -R $NB_UID:$NB_GID $HOME \

--- a/images/Dockerfile.allensdk
+++ b/images/Dockerfile.allensdk
@@ -32,6 +32,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
         brave-browser \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
+        libnss-wrapper \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
    && chown -R $NB_UID:$NB_GID $HOME \

--- a/images/Dockerfile.gpu
+++ b/images/Dockerfile.gpu
@@ -32,6 +32,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
         brave-browser \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
+        libnss-wrapper \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
    && chown -R $NB_UID:$NB_GID $HOME \

--- a/images/Dockerfile.gpu.allensdk
+++ b/images/Dockerfile.gpu.allensdk
@@ -32,6 +32,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
         brave-browser \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
+        libnss-wrapper \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
    && chown -R $NB_UID:$NB_GID $HOME \

--- a/images/Dockerfile.gpu.matlab
+++ b/images/Dockerfile.gpu.matlab
@@ -37,6 +37,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
        xorg \
        xubuntu-icon-theme \
        brave-browser \
+       libnss-wrapper \
     && rm -rf /tmp/*
 
 # Remove light-locker to prevent screen lock

--- a/images/Dockerfile.matlab
+++ b/images/Dockerfile.matlab
@@ -6,7 +6,12 @@ USER root
 # install extra apps, add extra folder and fix ownership in case apt-get messed with it
 ARG EXTRA_DIR=/opt/extras
 RUN apt-get update \
-    && apt-get install -y htop curl git build-essential \
+    && apt-get install -y \
+        htop \
+        libnss-wrapper \
+        curl \
+        git \
+        build-essential \
     && rm -rf /tmp/* \
     && mkdir ${EXTRA_DIR} \
     && chown -R $NB_UID:$NB_GID $HOME ${EXTRA_DIR}

--- a/images/Dockerfile.openscope
+++ b/images/Dockerfile.openscope
@@ -32,6 +32,7 @@ RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://br
         brave-browser \
         tigervnc-standalone-server \
         tigervnc-xorg-extension \
+        libnss-wrapper \
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root
    && chown -R $NB_UID:$NB_GID $HOME \


### PR DESCRIPTION
Nebari uses this for username emulation

https://github.com/orgs/nebari-dev/discussions/3060

This will fix an issue on nebari-deployments, when the user opens up a terminal they see 

`ERROR: ld.so: object 'libnss_wrapper.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored. `