### PR TITLE
Manifest of MATLAB image to be restored

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -10,8 +10,30 @@ This folder contains Dockerfiles to build various Docker images for Dandi:
 The MATLAB Docker image relies on the [MATLAB Integration for Jupyter in a Docker Container](https://github.com/mathworks-ref-arch/matlab-integration-for-jupyter).
 It is shipped with [MATLAB-proxy](https://github.com/mathworks/matlab-proxy) which enables communication with MATLAB from a web-browser, and with [MATLAB-proxy-jupyter](https://github.com/mathworks/jupyter-matlab-proxy) which adds MATLAB integration for Jupyter.
 
-This Dockerfile includes the following add-ons:
+This Dockerfile includes the following package, including platform products, toolbox products, and support packages from MathWorks(R) obtained via MATLAB Package Manager [(MPM)](https://www.mathworks.com/products/mpm.html), and additional add-on packages obtained from File Exchange and/or GitHub:
 
+| # | Package | Source | Version | Projected Update Strategy |
+| --- | --- | ---- | --- | --- |
+| 1 | MATLAB | MPM | R2025a | Penultimate MathWorks Release |
+| 2 | Bioinformatics Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
+| 3 | Computer Vision Toolbpx | MPM | R2025a | Penultimate MathWorks Release | 
+| 4 | Curve Fitting Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
+| 5 | Deep Learning Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
+| 6 | Econometrics Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
+| 7 | Financial Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
+| 8 | Image Processing Toolbox | MPM | R2025a | Penultimate MathWorks Release| 
+| 9 | Parallel Computing Toolbox | MPM | R2025a | Penultimate MathWorks Release |
+| 10 | Signal Processing Toolbox | MPM | R2025a | Penultimate MathWorks Release |
+| 11 | Statistics & Machine Learning Toolbox | MPM | R2025a | Penultimate MathWorks Release |
+| 12 | Wavelet Toolbox | MPM | R2025a | Penultimate MathWorks Release |
+| 13 | Deep Learning Toolbox Converter for TensorFlow Models | MPM | R2025a | Penultimate MathWorks Release
+| 14 | MatNWB | GitHub | Latest Commit | Latest Release |
+| 15 | Brain Observatory Toolbox | TODO | TODO |
+
+
+
+
+ 
 * matnwb v2.6.0.0
 * Brain-Observatory-Toolbox v0.9.2
 

--- a/images/README.md
+++ b/images/README.md
@@ -15,18 +15,18 @@ This Dockerfile includes the following package, including platform products, too
 | # | Package | Source | Current Version | Projected Update Strategy |
 | --- | :--- | :---- | :--- | :--- |
 | 1 | MATLAB | MPM | R2025a | Penultimate MathWorks Release |
-| 2 | Bioinformatics Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
-| 3 | Computer Vision Toolbpx | MPM | R2025a | Penultimate MathWorks Release | 
-| 4 | Curve Fitting Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
-| 5 | Deep Learning Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
-| 6 | Econometrics Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
-| 7 | Financial Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
-| 8 | Image Processing Toolbox | MPM | R2025a | Penultimate MathWorks Release| 
-| 9 | Parallel Computing Toolbox | MPM | R2025a | Penultimate MathWorks Release |
-| 10 | Signal Processing Toolbox | MPM | R2025a | Penultimate MathWorks Release |
-| 11 | Statistics & Machine Learning Toolbox | MPM | R2025a | Penultimate MathWorks Release |
-| 12 | Wavelet Toolbox | MPM | R2025a | Penultimate MathWorks Release |
-| 13 | Deep Learning Toolbox Converter for TensorFlow Models | MPM | R2025a | Penultimate MathWorks Release
+| 2 | Bioinformatics Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
+| 3 | Computer Vision Toolbpx | MPM | R2025b | Penultimate MathWorks Release | 
+| 4 | Curve Fitting Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
+| 5 | Deep Learning Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
+| 6 | Econometrics Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
+| 7 | Financial Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
+| 8 | Image Processing Toolbox | MPM | R2025b | Penultimate MathWorks Release| 
+| 9 | Parallel Computing Toolbox | MPM | R2025b | Penultimate MathWorks Release |
+| 10 | Signal Processing Toolbox | MPM | R2025b | Penultimate MathWorks Release |
+| 11 | Statistics & Machine Learning Toolbox | MPM | R2025b | Penultimate MathWorks Release |
+| 12 | Wavelet Toolbox | MPM | R2025b | Penultimate MathWorks Release |
+| 13 | Deep Learning Toolbox Converter for TensorFlow Models | MPM | R2025b | Penultimate MathWorks Release
 | 14 | [MatNWB](https://github.com/NeurodataWithoutBorders/matnwb) | GitHub | Commit 2c3a4e | Latest Release |
 | 15 | [Brain Observatory Toolbox](https://github.com/MATLAB-Community-Toolboxes-at-INCF/Brain-Observatory-Toolbox) | GitHub | v0.9.4.2 | Latest Release |
 | 16 | [Deep Interpolation Toolbox](https://github.com/MATLAB-Community-Toolboxes-at-INCF/DeepInterpolation-MATLAB) | GitHub | v0.9.1 | Latest Release |

--- a/images/README.md
+++ b/images/README.md
@@ -14,7 +14,7 @@ This Dockerfile includes the following package, including platform products, too
 
 | # | Package | Source | Current Version | Projected Update Strategy |
 | --- | :--- | :---- | :--- | :--- |
-| 1 | MATLAB | MPM | R2025a | Penultimate MathWorks Release |
+| 1 | MATLAB | MPM | R2025b | Penultimate MathWorks Release |
 | 2 | Bioinformatics Toolbox | MPM | R2025b | Penultimate MathWorks Release | 
 | 3 | Computer Vision Toolbpx | MPM | R2025b | Penultimate MathWorks Release | 
 | 4 | Curve Fitting Toolbox | MPM | R2025b | Penultimate MathWorks Release | 

--- a/images/README.md
+++ b/images/README.md
@@ -10,10 +10,10 @@ This folder contains Dockerfiles to build various Docker images for Dandi:
 The MATLAB Docker image relies on the [MATLAB Integration for Jupyter in a Docker Container](https://github.com/mathworks-ref-arch/matlab-integration-for-jupyter).
 It is shipped with [MATLAB-proxy](https://github.com/mathworks/matlab-proxy) which enables communication with MATLAB from a web-browser, and with [MATLAB-proxy-jupyter](https://github.com/mathworks/jupyter-matlab-proxy) which adds MATLAB integration for Jupyter.
 
-This Dockerfile includes the following package, including platform products, toolbox products, and support packages from MathWorks(R) obtained via MATLAB Package Manager [(MPM)](https://www.mathworks.com/products/mpm.html), and additional add-on packages obtained from File Exchange and/or GitHub:
+This Dockerfile includes the following package, including platform products, toolbox products, and support packages from MathWorks® obtained via MATLAB Package Manager [(MPM)](https://www.mathworks.com/products/mpm.html), and additional add-on packages obtained from File Exchange and/or GitHub®
 
-| # | Package | Source | Version | Projected Update Strategy |
-| --- | --- | ---- | --- | --- |
+| # | Package | Source | Current Version | Projected Update Strategy |
+| --- | :--- | :---- | :--- | :--- |
 | 1 | MATLAB | MPM | R2025a | Penultimate MathWorks Release |
 | 2 | Bioinformatics Toolbox | MPM | R2025a | Penultimate MathWorks Release | 
 | 3 | Computer Vision Toolbpx | MPM | R2025a | Penultimate MathWorks Release | 
@@ -27,15 +27,12 @@ This Dockerfile includes the following package, including platform products, too
 | 11 | Statistics & Machine Learning Toolbox | MPM | R2025a | Penultimate MathWorks Release |
 | 12 | Wavelet Toolbox | MPM | R2025a | Penultimate MathWorks Release |
 | 13 | Deep Learning Toolbox Converter for TensorFlow Models | MPM | R2025a | Penultimate MathWorks Release
-| 14 | MatNWB | GitHub | Latest Commit | Latest Release |
-| 15 | Brain Observatory Toolbox | TODO | TODO |
-
-
-
-
- 
-* matnwb v2.6.0.0
-* Brain-Observatory-Toolbox v0.9.2
+| 14 | [MatNWB](https://github.com/NeurodataWithoutBorders/matnwb) | GitHub | Commit 2c3a4e | Latest Release |
+| 15 | [Brain Observatory Toolbox](https://github.com/MATLAB-Community-Toolboxes-at-INCF/Brain-Observatory-Toolbox) | GitHub | v0.9.4.2 | Latest Release |
+| 16 | [Deep Interpolation Toolbox](https://github.com/MATLAB-Community-Toolboxes-at-INCF/DeepInterpolation-MATLAB) | GitHub | v0.9.1 | Latest Release |
+| 17 | [EXTRACT](https://github.com/schnitzer-lab/EXTRACT-public) | GitHub | Latest Commit | TBD |
+| 18 | [CIATAH](https://github.com/bahanonu/ciatah) | GitHub | Latest Commit | TBD |
+| 19 | [Example Live Scripts](https://github.com/MATLAB-Community-Toolboxes-at-INCF/example-live-scripts) | GitHub | Latest Commit | Latest Commit |
 
 ### How to Build
 


### PR DESCRIPTION
Add description of MATLAB image to be restored (with small refinements) to working order in the course of addressing #276. 

As discussed w/ the DANDI team, it's envisioned to share/track the contents of MATLAB (and potentially other) images on this or a README. This is a starting point to be used concurrent with #276. 

The location/format/etc for this and other DandiHub image manifests can be updated later. 