### PR TITLE
Add fully configured image for MATLAB 2025b 

### DIFF
--- a/images/matlab/Dockerfile
+++ b/images/matlab/Dockerfile
@@ -15,12 +15,8 @@ RUN apt update \
     && mkdir ${EXTRA_DIR} \
     && chown -R $NB_UID:$NB_GID $HOME ${EXTRA_DIR}
 
-RUN pip install --no-cache-dir datalad 'h5py>3.3' zarr pyopenssl plotly jupyter_bokeh jupytext nbgitpuller datalad_container \
-                datalad-osf dandi nibabel nilearn pybids spikeinterface neo \
-                'pydra>=0.25' 'pynwb>=2.8.3' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]" \
-                lxml kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr webio_jupyter_extension \
-                tensorstore anndata tensorflow \
-                xmlschema \
+COPY matlab-requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
           && pip install --no-cache-dir https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip --no-deps && \
           rm -rf /tmp/*
 

--- a/images/matlab/Dockerfile
+++ b/images/matlab/Dockerfile
@@ -1,17 +1,114 @@
-ARG MATLAB_RELEASE=r2024b
+ARG MATLAB_RELEASE=r2025b
 FROM ghcr.io/mathworks-ref-arch/matlab-integration-for-jupyter/jupyter-matlab-notebook:${MATLAB_RELEASE}
 
 USER root
 
-# Install libnss_wrapper for Nebari user identity handling
-RUN apt-get update && apt-get install -y --no-install-recommends libnss-wrapper \
-    && rm -rf /var/lib/apt/lists/*
+# install extra apps, add extra folder and fix ownership in case apt messed with it
+ARG EXTRA_DIR=/opt/extras
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        libnss-wrapper \
+        curl \
+        git \
+        build-essential \
+    && rm -rf /tmp/* \
+    && mkdir ${EXTRA_DIR} \
+    && chown -R $NB_UID:$NB_GID $HOME ${EXTRA_DIR}
 
+RUN pip install --no-cache-dir datalad 'h5py>3.3' zarr pyopenssl plotly jupyter_bokeh jupytext nbgitpuller datalad_container \
+                datalad-osf dandi nibabel nilearn pybids spikeinterface neo \
+                'pydra>=0.25' 'pynwb>=2.8.3' 'nwbwidgets>=0.10.2' hdf5plugin s3fs h5netcdf "xarray[io]" \
+                lxml kerchunk 'neuroglancer>=2.28' cloud-volume ipywidgets ome-zarr webio_jupyter_extension \
+                tensorstore anndata tensorflow \
+                xmlschema \
+          && pip install --no-cache-dir https://github.com/balbasty/dandi-io/archive/refs/heads/main.zip --no-deps && \
+          rm -rf /tmp/*
+
+# Install the required Toolboxes with user root
+# Optimization toolbox is a required dependency
+ARG MATLAB_RELEASE
+ARG TOOLBOXES="Bioinformatics_Toolbox \
+               Computer_Vision_Toolbox \
+               Curve_Fitting_Toolbox \
+               Deep_Learning_Toolbox \
+               Econometrics_Toolbox \
+               Financial_Toolbox \
+               Image_Processing_Toolbox \
+               Parallel_Computing_Toolbox \
+               Signal_Processing_Toolbox \
+               Statistics_and_Machine_Learning_Toolbox \
+               Wavelet_Toolbox \
+               Optimization_Toolbox \
+               Deep_Learning_Toolbox_Converter_for_TensorFlow_models"
+RUN wget -q https://www.mathworks.com/mpm/glnxa64/mpm && \
+    chmod +x mpm && \
+    ./mpm install \
+    --release=${MATLAB_RELEASE} \
+    --destination=/opt/matlab \
+    --products ${TOOLBOXES} && \
+    rm -f mpm /tmp/mathworks_root.log
+
+# Switch to NB_UID for addons and live-scripts installations
 USER $NB_UID
+
+## Adds add-ons and register them in the Matlab instance
+# Patch startup.m to automatically register the addons
+# The registration process simply iterate over all entries from the ADDONS_DIR folder
+# and add them to the "path"
+ARG ADDONS_DIR=${EXTRA_DIR}/dandi
+ARG STARTUP_SCRIPT=/opt/conda/lib/python3.13/site-packages/matlab_proxy/matlab/startup.m
+
+# Generate MATLAB startup script
+RUN echo -e "\n\
+% Set the number of workers for 'Processes' to 5\n\
+cluster = parcluster('Processes'); \n\
+cluster.NumWorkers = 5; \n\
+saveProfile(cluster); \n\
+ \n\
+% Copy the live-example folder \n\
+homedirExamples = strcat(getenv('HOME'), '/example-live-scripts') \n\
+if not(isfolder(homedirExamples)) \n\
+    repo = gitclone('https://github.com/MATLAB-Community-Toolboxes-at-INCF/example-live-scripts', homedirExamples, Depth=1); \n\
+end \n\
+% Add the example library to the path \n\
+addpath(homedirExamples); \n\
+% Add the addons to the path \n\
+addons = dir('${ADDONS_DIR}'); \n\
+addons = setdiff({addons([addons.isdir]).name}, {'.', '..'}); \n\
+for addon_idx = 1:numel(addons) \n\
+    addpath(genpath(strcat('${ADDONS_DIR}/', addons{addon_idx}))); \n\
+end \n\
+% generateCore();  % Generate the most recent nwb-schema \n\
+% ciapkg.io.loadDependencies('guiEnabled', 0);  % Load dependencies for CIAtah \n\
+% ADD HERE EXTRA ACTIONS FOR YOUR ADD-ON IF REQUIRED! \n\
+clear" >> ${STARTUP_SCRIPT}
+
+# Variables for addons management that are tied to a specific release, commit or bleeding edge
+ARG ADDONS_RELEASES="https://github.com/schnitzer-lab/EXTRACT-public/archive/refs/heads/master.zip \
+                     https://github.com/bahanonu/ciatah/archive/refs/heads/master.zip \
+                     https://github.com/NeurodataWithoutBorders/matnwb/archive/refs/tags/2.9.0.zip"
+
+# Add add-ons for Dandi: create the addons folder and download/unzip the addons
+RUN mkdir -p ${ADDONS_DIR} && \
+    cd ${ADDONS_DIR} && \
+    for addon in $ADDONS_RELEASES; do \
+       wget -O addon.zip $addon \
+       && unzip addon.zip \
+       && rm addon.zip; \
+    done
+
+# Variables for addons management that always takes the last release
+ARG ADDONS_LATEST="https://github.com/MATLAB-Community-Toolboxes-at-INCF/Brain-Observatory-Toolbox \
+                   https://github.com/MATLAB-Community-Toolboxes-at-INCF/DeepInterpolation-MATLAB"
+
+# Add add-ons for Dandi: detect/download/unzip the last release version
+RUN cd ${ADDONS_DIR} && \
+    for addon in $ADDONS_LATEST; do \
+       wget -O addon.zip $(echo "$addon/releases/latest" | sed 's/\/github.com\//\/api.github.com\/repos\//' | xargs wget -qO- |  grep zipball_url | cut -d '"' -f 4) \
+       && unzip addon.zip \
+       && rm addon.zip; \
+    done
 
 # Clear the ENTRYPOINT so Nebari can control startup
 ENTRYPOINT []
 CMD ["/bin/bash"]
-
-# Ensure MATLAB licensing env is set (might be needed without start.sh)
-ENV MW_CONTEXT_TAGS=MATLAB_PROXY:JUPYTER:V1

--- a/images/matlab/matlab-requirements.txt
+++ b/images/matlab/matlab-requirements.txt
@@ -1,0 +1,38 @@
+# required by the Deep Learning Toolbox Converter for TensorFlow models
+tensorstore
+tensorflow
+
+# required for dandi-io
+datalad_container
+dandi
+datalad-osf
+datalad
+lxml
+xmlschema
+
+# pyopenssl
+# plotly
+# jupyter_bokeh
+# jupytext
+# nbgitpuller
+# nibabel
+# nilearn
+# pybids
+# spikeinterface
+# neo
+# pydra>=0.25
+# nwbwidgets>=0.10.2
+# s3fs
+# h5netcdf
+# xarray[io]
+# kerchunk
+# neuroglancer>=2.28
+# cloud-volume
+# ipywidgets
+# webio_jupyter_extension
+# anndata
+# pynwb
+# h5py
+# hdf5plugin
+# ome-zarr
+# zarr


### PR DESCRIPTION
## Summary

Upgrades the MATLAB image to target MATALAB 2025b, iterating on the MATLAB for Nebari base Dockerfile created by @asmacdo in #283 .

## What's Changed

* Re-introduction of Python dependencies and tooling for the interaction with the MATLAB toolboxes using Python as backend
* Re-introduction of MATLAB official toolboxes as defined in the [manifest](https://github.com/vijayiyer05/dandi-hub/tree/patch-1/images) with the addition of some necessary toolboxes dependencies
* Re-introduction of the Deep Learning Toolbox Converter for TensorFlow Models
* Re-introduction of the third-party libraries with adequate version as defined in the [manifest](https://github.com/vijayiyer05/dandi-hub/tree/patch-1/images), with exception of matNWB which have been pinned to `2.9.0` because of an apparent regression introduced in `2.10.0` which breaks the live-script examples.
* Cleaning of some Python dependencies
* Change the way the `dandi-io` library is installed as it relies on a dependency that is not supported for Python >= 3.13
* Remove the ENTRYPOINT as described in #283 to let the startup process to Nebari