### PR TITLE
Free up disk space before matlab build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -47,6 +47,12 @@ jobs:
   build-matlab:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet  # .NET SDK
+          sudo rm -rf /opt/ghc           # Haskell compiler
+          sudo rm -rf /usr/local/share/boost  # Boost C++ libs
+
       - uses: actions/checkout@v4
 
       - uses: docker/login-action@v3


### PR DESCRIPTION
matlab build succeeded on CI, but on merge, the build&push job failed due to the extra space needed for compression prior to push. Hoping that this extra space will be enough